### PR TITLE
Refactor Docker setup for Phaser game deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,4 @@ COPY src/ ./src/
 RUN npm install
 RUN npm run build
 
-FROM nginx:alpine
-COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/nginx.conf
-
-RUN mkdir -p /etc/nginx/ssl
-EXPOSE 8080
-
-CMD ["nginx", "-g", "daemon off;"] 
+CMD ["tail", "-f", "/dev/null"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,27 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
     volumes:
+      - ./dist:/usr/share/nginx/html
+    networks:
+      - game-network
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8090:8090"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./dist:/usr/share/nginx/html
       - ./cert.pem:/etc/nginx/ssl/cert.pem
       - ./fullchain.pem:/etc/nginx/ssl/fullchain.pem
       - ./privkey.pem:/etc/nginx/ssl/privkey.pem
-    restart: unless-stopped 
+    depends_on:
+      - phaser-game
+    networks:
+      - game-network
+    restart: unless-stopped
+
+networks:
+  game-network:
+    driver: bridge 

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,7 +7,7 @@ http {
     default_type  application/octet-stream;
 
     server {
-        listen 8080;
+        listen 8080 ssl;
         server_name gamemagma.live www.gamemagma.live;
         
         ssl_certificate /etc/nginx/ssl/fullchain.pem;


### PR DESCRIPTION
- Updated docker-compose.yml to define a new 'nginx' service and added a custom network for better service isolation.
- Changed the exposed port for the nginx service from 8080 to 8090 and configured SSL settings in nginx.conf.
- Modified Dockerfile to remove the multi-stage build and keep the container running with a tail command.

This enhances the deployment workflow by improving service management and SSL configuration.